### PR TITLE
Feature/password hasher

### DIFF
--- a/hotline/password_update.py
+++ b/hotline/password_update.py
@@ -1,0 +1,43 @@
+from django.utils.crypto import get_random_string
+
+from hotline.users.models import User
+from hotline.users.utils import RubyPasswordHasher
+
+"""
+    So here we got a little script to move all the passwords from the old site to the new one.
+    The old passwords should be a 64 character string representing the sha256 hash of the password.
+    So something like
+
+        v3aiiff13720e8ad9047dd39466b332974e592c2fa383d4a3960714caefzc4f2
+        ^
+        NOTE: not an actual hash so don't go messin' with it or anything.
+        Your efforts will be fruitless and boring.
+
+    This script takes the raw password from the database, seasons it with some salt, and grills
+    it in the encode method of the RubyPasswordHasher class.
+    The resulting string is in the official Django format, e.g.
+
+        <algorithm>$<iterations>$<salt>$<hash>
+
+    Bam! And there you have it. Hot new password fresh off the grill. Serve with fries, and peace of mind.
+"""
+
+PASS_LENGTH = 64
+
+algorithm = "RubyPasswordHasher"
+hasher = RubyPasswordHasher()
+
+
+def update():
+    users = User.objects.all()
+    for user in users:
+        password = user.password
+        if len(password) == PASS_LENGTH:
+            # Password is just a SHA256 hash. gotta prefix it and all
+            salt = get_random_string(8)
+            hashed = hasher.encode(password, salt)
+            user.password = hashed
+            user.save()
+            print(user.password)
+
+update()

--- a/hotline/settings.py
+++ b/hotline/settings.py
@@ -170,6 +170,11 @@ MIDDLEWARE_CLASSES = (
     # 'djangocas.middleware.CASMiddleware',
 )
 
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'hotline.users.utils.RubyPasswordHasher',
+)
+
 ROOT_URLCONF = 'hotline.urls'
 
 WSGI_APPLICATION = 'hotline.wsgi.application'

--- a/hotline/users/tests.py
+++ b/hotline/users/tests.py
@@ -252,9 +252,19 @@ class UtilsTest(TestCase):
 
     def setUp(self):
         self.hasher = RubyPasswordHasher()
+        self.password = "foobar"
+        self.encoded = hashlib.sha256(self.password.encode("utf-8")).hexdigest() # duplicate original encoding scheme
 
     def test_encoding(self):
-        password = "foobar"
-        encoded = hashlib.sha256(password.encode("utf-8")).hexdigest() # duplicate original encoding scheme
-        new = self.hasher.encode(encoded, self.hasher.salt())
-        self.assertTrue(self.hasher.verify(password, new))
+        new = self.hasher.encode(self.encoded, self.hasher.salt())
+        self.assertTrue(self.hasher.verify(self.password, new))
+
+    def test_salt(self):
+        # LOL
+        salty = 8
+        salt = self.hasher.salt()
+        self.assertEqual(len(salt), salty)
+        self.assertNotIn('$', salt)
+
+    def test_must_update(self):
+        self.assertTrue(self.hasher.must_update(self.encoded))

--- a/hotline/users/tests.py
+++ b/hotline/users/tests.py
@@ -1,3 +1,4 @@
+import hashlib
 import urllib.parse
 from unittest.mock import Mock, patch
 
@@ -11,6 +12,7 @@ from hotline.reports.models import Invite, Report
 
 from .forms import LoginForm, UserForm
 from .models import User
+from .utils import RubyPasswordHasher
 
 
 class DetailViewTest(TestCase):
@@ -244,3 +246,15 @@ class LoginViewTest(TestCase):
         })
         self.assertTrue(len(mail.outbox), 1)
         self.assertRedirects(response, reverse("login"))
+
+
+class UtilsTest(TestCase):
+
+    def setUp(self):
+        self.hasher = RubyPasswordHasher()
+
+    def test_encoding(self):
+        password = "foobar"
+        encoded = hashlib.sha256(password.encode("utf-8")).hexdigest() # duplicate original encoding scheme
+        new = self.hasher.encode(encoded, self.hasher.salt())
+        self.assertTrue(self.hasher.verify(password, new))

--- a/hotline/users/utils.py
+++ b/hotline/users/utils.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from django.contrib.auth.hashers import BasePasswordHasher, mask_hash
 from django.utils.crypto import get_random_string, pbkdf2
+from django.utils.translation import ugettext_noop as _
 
 
 class RubyPasswordHasherInvalidHashException(Exception):
@@ -38,7 +39,7 @@ class RubyPasswordHasher(BasePasswordHasher):
         if not iterations:
             iterations = self.iterations
         hashed = hashlib.sha256(password.encode("utf-8")).hexdigest()
-        hash = pbkdf2(password, salt, iterations, digest=self.digest)
+        hash = pbkdf2(hashed, salt, iterations, digest=self.digest)
         hash = base64.b64encode(hash).decode('ascii').strip()
         return "%s$%d$%s$%s" % (self.algorithm, iterations, salt, hash)
 

--- a/hotline/users/utils.py
+++ b/hotline/users/utils.py
@@ -1,0 +1,60 @@
+import base64
+import hashlib
+from collections import OrderedDict
+
+from django.contrib.auth.hashers import BasePasswordHasher, mask_hash
+from django.utils.crypto import get_random_string, pbkdf2
+
+
+class RubyPasswordHasherInvalidHashException(Exception):
+    pass
+
+
+class RubyPasswordHasher(BasePasswordHasher):
+    """
+    A password hasher that re-hashes the passwords from the old site so they can be used here.
+    Encryption (old): Sha256
+    """
+    algorithm = "RubyPasswordHasher"
+    iterations = 1500
+    digest = hashlib.sha256
+
+    def verify(self, password, encoded):
+        """
+        Actually, I think the only thing we have to do here is check that
+        encoded_2 == encrypted
+        instead of password == encrypted
+        """
+        algorithm, iterations, salt, hash = encoded.split('$', 3)
+        assert algorithm == self.algorithm
+        # here's the extra step
+        hashed = hashlib.sha256(password.encode("utf-8")).hexdigest()
+        encoded_2 = self.encode(hashed, salt)
+        return encoded_2 == encoded
+
+    def encode(self, password, salt, iterations=None):
+        assert password is not None
+        assert salt and '$' not in salt
+        if not iterations:
+            iterations = self.iterations
+        hashed = hashlib.sha256(password.encode("utf-8")).hexdigest()
+        hash = pbkdf2(password, salt, iterations, digest=self.digest)
+        hash = base64.b64encode(hash).decode('ascii').strip()
+        return "%s$%d$%s$%s" % (self.algorithm, iterations, salt, hash)
+
+    def salt(self):
+        return get_random_string(8)
+
+    def safe_summary(self, encoded):
+        algorithm, iterations, salt, hash = encoded.split('$', 3)
+        assert algorithm == self.algorithm
+        return OrderedDict([
+            (_('algorithm'), algorithm),
+            (_('iterations'), iterations),
+            (_('salt'), mask_hash(salt)),
+            (_('hash'), mask_hash(hash)),
+        ])
+
+    def must_update(self, encoded):
+        algorithm, iterations, salt, hash = encoded.split('$', 3)
+        return int(iterations) != self.iterations

--- a/hotline/users/utils.py
+++ b/hotline/users/utils.py
@@ -57,5 +57,10 @@ class RubyPasswordHasher(BasePasswordHasher):
         ])
 
     def must_update(self, encoded):
-        algorithm, iterations, salt, hash = encoded.split('$', 3)
-        return int(iterations) != self.iterations
+        try:
+            algorithm, iterations, salt, hash = encoded.split('$', 3)
+            return int(iterations) != self.iterations or algorithm != self.algorithm
+        except ValueError:
+            return True
+            # needs more than one value to unpack, aka this is only a sha256 hash
+            # so yeah it definitely should be updated.


### PR DESCRIPTION
Django has interesting behavior when it comes to password hashers.
I guess it walks through the list of hashers until it finds one that works on the specified password, then it goes and re-encodes the password using the first hasher specified in the settings file.
Which is cool because it's efficient (I guess?) but kinda a pain because I wrote the new password hasher that will apparently only be used twice per old password; Once to verify the old password and re-encode it for the data migration, and once the first time the user logs in to their account. After that the password will be re-encoded using the first specified hasher.
Man I'm bringing this up in the meeting as a "what you learned this week" type thing.

I'm also probably gonna have to redo a bit of it since it's only used twice per qualified user. Oh well. NBD.
