### PR TITLE
Add pagination to users/species list view

### DIFF
--- a/oregoninvasiveshotline/species/views.py
+++ b/oregoninvasiveshotline/species/views.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.urlresolvers import reverse, reverse_lazy
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import render
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
@@ -14,6 +16,16 @@ from oregoninvasiveshotline.species.models import Category, Severity, Species
 def list_(request):
     form = SpeciesSearchForm(request.GET, user=request.user)
     species = form.search()
+
+    paginator = Paginator(species, settings.ITEMS_PER_PAGE)
+
+    active_page = request.GET.get('page')
+    try:
+        species = paginator.page(active_page)
+    except PageNotAnInteger:
+        species = paginator.page(1)
+    except EmptyPage:
+        species = paginator.page(paginator.num_pages)
 
     return render(request, 'species/list.html', {
         "all_species": species,

--- a/oregoninvasiveshotline/users/views.py
+++ b/oregoninvasiveshotline/users/views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as django_login
 from django.contrib.auth.views import login as django_login_view
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.signing import BadSignature
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import DetailView
@@ -124,6 +125,16 @@ def list_(request):
 
     form = UserSearchForm(request.GET)
     users = form.search()
+
+    paginator = Paginator(users, settings.ITEMS_PER_PAGE)
+
+    active_page = request.GET.get('page')
+    try:
+        users = paginator.page(active_page)
+    except PageNotAnInteger:
+        users = paginator.page(1)
+    except EmptyPage:
+        users = paginator.page(paginator.num_pages)
 
     return render(request, "users/list.html", {
         "users": users,


### PR DESCRIPTION
Elasticmodels used wrap results from form.search() in a pageable on this site. Since we've swapped elasticmodels for haystack, and form.search() no longer extends that functionality, we add pagination functionality to the species and users list views.