### PR TITLE
Add county label property and fix county/user ordering

### DIFF
--- a/oregoninvasiveshotline/counties/migrations/0003_auto_20160209_2102.py
+++ b/oregoninvasiveshotline/counties/migrations/0003_auto_20160209_2102.py
@@ -1,0 +1,17 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('counties', '0002_auto_20150804_1609'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='county',
+            options={'ordering': ['state', 'name']},
+        ),
+    ]

--- a/oregoninvasiveshotline/counties/models.py
+++ b/oregoninvasiveshotline/counties/models.py
@@ -22,4 +22,4 @@ class County(models.Model):
         return '{0.name}, {0.state}'.format(self)
 
     def __str__(self):
-        return self.name
+        return self.label

--- a/oregoninvasiveshotline/counties/models.py
+++ b/oregoninvasiveshotline/counties/models.py
@@ -13,5 +13,13 @@ class County(models.Model):
         db_table = 'county'
         ordering = ['state', 'name']
 
+    @property
+    def label(self):
+        if self.state == 'Oregon':
+            return self.name
+        elif self.state == 'Washington':
+            return '{0.name}, WA'.format(self)
+        return '{0.name}, {0.state}'.format(self)
+
     def __str__(self):
         return self.name

--- a/oregoninvasiveshotline/counties/models.py
+++ b/oregoninvasiveshotline/counties/models.py
@@ -10,7 +10,8 @@ class County(models.Model):
     objects = models.GeoManager()
 
     class Meta:
-        db_table = "county"
+        db_table = 'county'
+        ordering = ['state', 'name']
 
     def __str__(self):
         return self.name

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -28,13 +28,7 @@ def get_category_choices():
 def get_county_choices():
     county_choices = []
     for county in County.objects.all().order_by('state', 'name'):
-        if county.state == 'Oregon':
-            label = county.name
-        elif county.state == 'Washington':
-            label = '{0.name}, WA'.format(county)
-        else:
-            label = '{0.name}, {0.state}'.format(county)
-        county_choices.append((county.pk, label))
+        county_choices.append((county.pk, county.label))
     return county_choices
 
 

--- a/oregoninvasiveshotline/users/migrations/0007_auto_20160209_2111.py
+++ b/oregoninvasiveshotline/users/migrations/0007_auto_20160209_2111.py
@@ -1,0 +1,17 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0006_auto_20151013_1331'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='user',
+            options={'ordering': ['first_name', 'last_name']},
+        ),
+    ]

--- a/oregoninvasiveshotline/users/models.py
+++ b/oregoninvasiveshotline/users/models.py
@@ -31,7 +31,7 @@ class User(AbstractBaseUser):
 
     class Meta:
         db_table = "user"
-        ordering = ['last_name', 'first_name']
+        ordering = ['first_name', 'last_name']
 
     def get_avatar_url(self):
         if self.photo:


### PR DESCRIPTION
- Adds a `label` property to the county model, derived from the logic implemented in `get_county_choices()`, which is both useful and cleans up the code.
- Fix county ordering to order by `state` first, then by `name`. This provides implicit separation of Oregon and Washington counties.
- Fix user ordering to order by `first_name`, then by `last_name.