### PR TITLE
Make admin GIS map load over HTTPS

### DIFF
--- a/oregoninvasiveshotline/reports/admin.py
+++ b/oregoninvasiveshotline/reports/admin.py
@@ -1,5 +1,14 @@
 from django.contrib import admin
+from django.contrib.gis.admin.options import GeoModelAdmin
 
 from .models import Report
 
-admin.site.register(Report)
+
+class CustomGeoModelAdmin(GeoModelAdmin):
+    """A custom administration options class for Geographic models"""
+
+    # Use a non-default URL so openlayers can be used over HTTPS
+    openlayers_url = 'https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js'
+
+
+admin.site.register(Report, CustomGeoModelAdmin)


### PR DESCRIPTION
By default, Django's `GeoModelAdmin` uses openlayers whose URL is not
available via HTTPS. To get around this, we subclass GeoModelAdmin and
swap the openlayers_url for one that's available over HTTPS.