### PR TITLE
Make first and last names nullable

### DIFF
--- a/oregoninvasiveshotline/users/migrations/0008_make_first_and_last_name_nullable
+++ b/oregoninvasiveshotline/users/migrations/0008_make_first_and_last_name_nullable
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+def empty_strings_to_null(apps, schema_editor):
+    model = apps.get_model('users', 'User')
+    model.objects.filter(first_name='').update(first_name=None)
+    model.objects.filter(last_name='').update(last_name=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0007_fix_default_ordering_of_user_model'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='first_name',
+            field=models.CharField(null=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='last_name',
+            field=models.CharField(null=True, max_length=255),
+        ),
+
+        migrations.RunPython(empty_strings_to_null),
+    ]

--- a/oregoninvasiveshotline/users/models.py
+++ b/oregoninvasiveshotline/users/models.py
@@ -21,8 +21,8 @@ class User(AbstractBaseUser):
 
     user_id = models.AutoField(primary_key=True)
     email = models.EmailField(max_length=255, unique=True)
-    first_name = models.CharField(max_length=255)
-    last_name = models.CharField(max_length=255)
+    first_name = models.CharField(max_length=255, null=True)
+    last_name = models.CharField(max_length=255, null=True)
     phone = models.CharField(max_length=255, default="", blank=True)
     prefix = models.CharField(max_length=255)
     suffix = models.CharField(max_length=255)

--- a/oregoninvasiveshotline/users/search_indexes.py
+++ b/oregoninvasiveshotline/users/search_indexes.py
@@ -7,8 +7,8 @@ class UserIndex(indexes.SearchIndex, indexes.Indexable):
 
     text = indexes.CharField(document=True, use_template=True)
     email = indexes.CharField(model_attr='email')
-    first_name = indexes.CharField(model_attr='first_name')
-    last_name = indexes.CharField(model_attr='last_name')
+    first_name = indexes.CharField(model_attr='first_name', null=True)
+    last_name = indexes.CharField(model_attr='last_name', null=True)
 
     # Data fields (stored by not indexed)
     full_name = indexes.CharField(model_attr='full_name', indexed=False)


### PR DESCRIPTION
This is to prevent an empty string from being stored in either the
`first_name` or `last_name` fields, which will list users with an empty
string in either field at the front of a user queryset.