### PR TITLE
Fix active users receiving auto-login link

### DIFF
--- a/oregoninvasiveshotline/comments/forms.py
+++ b/oregoninvasiveshotline/comments/forms.py
@@ -1,30 +1,34 @@
 from django import forms
+from django.conf import settings
 from django.core.mail import send_mass_mail
 from django.template.loader import render_to_string
 
-from oregoninvasiveshotline.reports.models import Invite
-from oregoninvasiveshotline.reports.perms import can_adjust_visibility
-from oregoninvasiveshotline.users.models import User
+from ..reports.models import Invite
+from ..reports.perms import can_adjust_visibility
+from ..users.models import User
 
 from .models import Comment
 
 
 class CommentForm(forms.ModelForm):
-    SUBMIT_FLAG = "COMMENT"
+
+    SUBMIT_FLAG = 'COMMENT'
 
     class Meta:
         model = Comment
-        fields = [
+        fields = (
             'body',
             'visibility',
-        ]
+        )
 
     def __init__(self, *args, user, report, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields['body'].label = ""
-        self.fields['body'].widget.attrs['placeholder'] = "Comment body..."
-        self.fields['body'].widget.attrs['rows'] = 3
+        self.fields['body'].label = ''
+        self.fields['body'].widget.attrs.update({
+            'placeholder': 'Comment body...',
+            'rows': 3,
+        })
 
         if self.instance.pk is None:
             self.instance.report = report
@@ -35,45 +39,50 @@ class CommentForm(forms.ModelForm):
             self.instance.visibility = Comment.PROTECTED
 
     def save(self, *args, request, **kwargs):
-        is_new = self.instance.pk is None
-        to_return = super().save(*args, **kwargs)
+        is_new = self.instance.pk is None  # Must be before save
+        instance = super().save(*args, **kwargs)
         if is_new:
-            # when a new comment is made, send out an email to the relevant
-            # people
-            # any managers or staff who commented on this should get notified
-            to_notify = set(
-                Comment.objects.filter(report=self.instance.report, created_by__is_active=True).values_list(
-                    "created_by__email",
-                    flat=True
-                )
-            )
-            # whoever claimed the report should get notified
-            if self.instance.report.claimed_by:
-                to_notify.add(self.instance.report.claimed_by.email)
+            self.notify_users(request)
+        return instance
 
-            # all invited experts should be notified
-            to_notify |= set(Invite.objects.filter(report=self.instance.report).values_list("user__email", flat=True))
+    def notify_users(self, request):
+        # Send an email notification about the comment to the relevant
+        # users.
+        comment = self.instance
+        report = comment.report
 
-            # notify the person who submitted the report if it is PUBLIC or PROTECTED
-            if self.instance.visibility in [Comment.PROTECTED, Comment.PUBLIC]:
-                to_notify.add(self.instance.report.created_by.email)
+        recipients = set()
 
-            # don't notify yourself
-            to_notify.discard(self.instance.created_by.email)
+        # Notify staff & managers who commented on the report
+        q = Comment.objects.filter(report=report, created_by__is_active=True)
+        recipients.update(q.values_list('created_by__email', flat=True))
 
-            letters = []
-            for email in to_notify:
-                letters.append((
-                    "OregonInvasivesHotline.org - New Comment on Report",
-                    render_to_string("reports/_new_comment.txt", {
-                        "user": self.instance.created_by,
-                        "body": self.instance.body,
-                        "url": User(email=email).get_authentication_url(request, next=self.instance.get_absolute_url())
-                    }),
-                    "noreply@pdx.edu",
-                    [email]
-                ))
+        # Notify the user who claimed the report
+        if comment.report.claimed_by:
+            recipients.add(report.claimed_by.email)
 
-            send_mass_mail(letters)
+        # Notify invited experts
+        q = Invite.objects.filter(report=report)
+        recipients.update(q.values_list('user__email', flat=True))
 
-        return to_return
+        # Notify the user that submitted the report
+        if comment.visibility in (Comment.PROTECTED, Comment.PUBLIC):
+            recipients.add(report.created_by.email)
+
+        # Don't notify the user who made the comment
+        recipients.discard(comment.created_by.email)
+
+        emails = []
+        subject = '{0.PROJECT[title]} - New Comment on Report'.format(settings)
+
+        for recipient in recipients:
+            user = User(email=recipient)
+            url = user.get_authentication_url(request, next=comment.get_absolute_url())
+            body = render_to_string('reports/_new_comment.txt', {
+                'user': comment.created_by,
+                'body': comment.body,
+                'url': url,
+            })
+            emails.append((subject, body, 'noreply@pdx.edu', (recipient,)))
+
+        send_mass_mail(emails)

--- a/oregoninvasiveshotline/notifications/models.py
+++ b/oregoninvasiveshotline/notifications/models.py
@@ -57,7 +57,11 @@ class UserNotificationQuery(models.Model):
                     form = ReportSearchForm(QueryDict(query), user=user)
                     if form.is_valid() and form.search().filter(id=report.pk).count():
                         next_url = reverse('reports-detail', args=[report.pk])
-                        url = user.get_authentication_url(request=request, next=next_url)
+                        # Only provide an auto-login URL if user is public
+                        if user.is_active:
+                            url = request.build_absolute_uri(next_url)
+                        else:
+                            url = user.get_authentication_url(request=request, next=next_url)
                         body = render_to_string('notifications/email.txt', {
                             'user': user,
                             'name': user_notification_query.name,

--- a/oregoninvasiveshotline/templates/users/list.html
+++ b/oregoninvasiveshotline/templates/users/list.html
@@ -18,10 +18,6 @@
     <br>
 
     {% if users %}
-        <p class="alert alert-info">
-            <span class="glyphicon glyphicon-info-sign"></span>
-            Note: <i>Users that <b>don't</b> have a first or last name set appear first in this list.</i>
-        </p>
         <table class="table table-condensed table-striped">
             <thead>
                 <tr>


### PR DESCRIPTION
- Remove notice on user-list page
- When a comment is posted or new report submitted, make sure active users are sent a regular URL and public users are sent an auto-login URL